### PR TITLE
bally: add DIP switch documentation for AS-2518-35 games

### DIFF
--- a/maps/bally/as-2518-35/embryon.map.json
+++ b/maps/bally/as-2518-35/embryon.map.json
@@ -19,7 +19,69 @@
     "platform": "bally-35-8K",
     "roms": [
       "embryon"
-    ]
+    ],
+    "values": {
+      "_notes": [
+        "DIP switch settings from the Bally Embryon manual (game #1222, FO 703).",
+        "incentive: X@Y means X credits paid on the Yth coin"
+      ],
+      "off_on": [
+        "off",
+        "on"
+      ],
+      "pricing": [
+        "1 credit/coin",
+        "2 credits/coin",
+        "3 credits/coin",
+        "4 credits/coin",
+        "5 credits/coin",
+        "6 credits/coin",
+        "7 credits/coin",
+        "8 credits/coin",
+        "9 credits/coin",
+        "12 credits/coin",
+        "14 credits/coin",
+        "1 credit/2 coins",
+        "2 credits/2 coins",
+        "3 credits/2 coins",
+        "4 credits/2 coins",
+        "5 credits/2 coins",
+        "6 credits/2 coins",
+        "7 credits/2 coins",
+        "8 credits/2 coins",
+        "9 credits/2 coins",
+        "12 credits/2 coins",
+        "14 credits/2 coins",
+        "incentive: 1@1, 2@2 (3/2)",
+        "incentive: 1@2, 1@3, 1@4 (3/4)",
+        "incentive: 1@2, 2@4 (3/4)",
+        "incentive: 1@1, 1@2, 1@3, 2@4 (5/4)",
+        "incentive: 1@1, 2@2, 1@3, 3@4 (7/4)",
+        "incentive: 1@1, 2@2, 2@3, 2@4 (7/4)",
+        "1 credit/3 coins",
+        "1 credit/4 coins",
+        "1 credit/5 coins",
+        "incentive: 1@3, 1@5 (2/5)"
+      ],
+      "pricing_chute3": [
+        "same as chute 1",
+        "1 credit/coin",
+        "2 credits/coin",
+        "3 credits/coin",
+        "4 credits/coin",
+        "5 credits/coin",
+        "6 credits/coin",
+        "7 credits/coin",
+        "8 credits/coin",
+        "9 credits/coin",
+        "10 credits/coin",
+        "11 credits/coin",
+        "12 credits/coin",
+        "13 credits/coin",
+        "14 credits/coin",
+        "15 credits/coin"
+      ]
+    }
   },
   "game_state": {
     "_notes": [
@@ -330,6 +392,197 @@
         "max": 3,
         "suffix": " credits"
       }
+    }
+  },
+  "dip_switches": {
+    "1-5": {
+      "_notes": "Full pricing table from the manual; X/2 coins settings pay all credits on the 2nd coin.",
+      "label": "Coin Chute #1 (hinge side) Credits/Coin",
+      "encoding": "dipsw",
+      "offsets": [
+        5,
+        4,
+        3,
+        2,
+        1
+      ],
+      "values": "pricing"
+    },
+    "6": {
+      "label": "Top Drop Targets Feature",
+      "encoding": "dipsw",
+      "offsets": [
+        6
+      ],
+      "values": [
+        "collect feature on 2nd completion",
+        "collect feature on 1st completion"
+      ]
+    },
+    "7": {
+      "label": "Memory for 10K/20K/40K Bonus and Special",
+      "encoding": "dipsw",
+      "offsets": [
+        7
+      ],
+      "values": "off_on"
+    },
+    "8": {
+      "label": "Memory for Bonus Multipliers",
+      "encoding": "dipsw",
+      "offsets": [
+        8
+      ],
+      "values": "off_on"
+    },
+    "9-13": {
+      "_notes": "Full pricing table from the manual; X/2 coins settings pay all credits on the 2nd coin.",
+      "label": "Coin Chute #3 (right side) Credits/Coin",
+      "encoding": "dipsw",
+      "offsets": [
+        13,
+        12,
+        11,
+        10,
+        9
+      ],
+      "values": "pricing"
+    },
+    "14": {
+      "label": "Memory for Top Center Lane Values",
+      "encoding": "dipsw",
+      "offsets": [
+        14
+      ],
+      "values": "off_on"
+    },
+    "15": {
+      "label": "Memory for Right Side Stand Up Target Values",
+      "encoding": "dipsw",
+      "offsets": [
+        15
+      ],
+      "values": "off_on"
+    },
+    "16": {
+      "label": "Memory for Left Side Stand Up Target Values",
+      "encoding": "dipsw",
+      "offsets": [
+        16
+      ],
+      "values": "off_on"
+    },
+    "17-20": {
+      "label": "Coin Chute #2 (center) Credits/Coin",
+      "encoding": "dipsw",
+      "offsets": [
+        20,
+        19,
+        18,
+        17
+      ],
+      "values": "pricing_chute3"
+    },
+    "21": {
+      "label": "Inside Target Lites Outside Targets",
+      "encoding": "dipsw",
+      "offsets": [
+        21
+      ],
+      "values": [
+        "1 outside lite",
+        "2 outside lites"
+      ]
+    },
+    "22": {
+      "label": "Memory for Center Outside Target Lites",
+      "encoding": "dipsw",
+      "offsets": [
+        22
+      ],
+      "values": "off_on"
+    },
+    "23": {
+      "label": "Memory for 1 and 2 Top Lane Lites",
+      "encoding": "dipsw",
+      "offsets": [
+        23
+      ],
+      "values": "off_on"
+    },
+    "24": {
+      "label": "Memory for A and B Lane Lites (Flipsave)",
+      "encoding": "dipsw",
+      "offsets": [
+        24
+      ],
+      "values": "off_on"
+    },
+    "25-26": {
+      "label": "Maximum Credits",
+      "encoding": "dipsw",
+      "offsets": [
+        26,
+        25
+      ],
+      "values": [
+        10,
+        15,
+        25,
+        40
+      ]
+    },
+    "27": {
+      "label": "Credits Displayed",
+      "encoding": "dipsw",
+      "offsets": [
+        27
+      ],
+      "values": "off_on"
+    },
+    "28": {
+      "label": "Match Feature",
+      "encoding": "dipsw",
+      "offsets": [
+        28
+      ],
+      "values": "off_on"
+    },
+    "29": {
+      "label": "Replays per Game",
+      "encoding": "dipsw",
+      "offsets": [
+        29
+      ],
+      "values": [
+        "only 1 replay per player per game",
+        "all replays earned collected"
+      ]
+    },
+    "30": {
+      "label": "Game Over Attract Voice",
+      "encoding": "dipsw",
+      "offsets": [
+        30
+      ],
+      "values": [
+        "no voice",
+        "voice says 'Activate Embryon'"
+      ]
+    },
+    "31-32": {
+      "label": "Balls per Game",
+      "encoding": "dipsw",
+      "offsets": [
+        31,
+        32
+      ],
+      "values": [
+        3,
+        4,
+        5,
+        2
+      ]
     }
   }
 }

--- a/maps/bally/as-2518-35/gransla4.map.json
+++ b/maps/bally/as-2518-35/gransla4.map.json
@@ -19,7 +19,69 @@
     "platform": "bally-35-8K",
     "roms": [
       "gransla4"
-    ]
+    ],
+    "values": {
+      "_notes": [
+        "DIP switch settings from the Bally Grand Slam manual (game #1311, FO 770).",
+        "incentive: X@Y means X credits paid on the Yth coin"
+      ],
+      "off_on": [
+        "off",
+        "on"
+      ],
+      "pricing": [
+        "1 credit/coin",
+        "2 credits/coin",
+        "3 credits/coin",
+        "4 credits/coin",
+        "5 credits/coin",
+        "6 credits/coin",
+        "7 credits/coin",
+        "8 credits/coin",
+        "9 credits/coin",
+        "12 credits/coin",
+        "14 credits/coin",
+        "1 credit/2 coins",
+        "2 credits/2 coins",
+        "3 credits/2 coins",
+        "4 credits/2 coins",
+        "5 credits/2 coins",
+        "6 credits/2 coins",
+        "7 credits/2 coins",
+        "8 credits/2 coins",
+        "9 credits/2 coins",
+        "12 credits/2 coins",
+        "14 credits/2 coins",
+        "incentive: 1@1, 2@2 (3/2)",
+        "incentive: 1@2, 1@3, 1@4 (3/4)",
+        "incentive: 1@2, 2@4 (3/4)",
+        "incentive: 1@1, 1@2, 1@3, 2@4 (5/4)",
+        "incentive: 1@1, 2@2, 1@3, 3@4 (7/4)",
+        "incentive: 1@1, 2@2, 2@3, 2@4 (7/4)",
+        "1 credit/3 coins",
+        "1 credit/4 coins",
+        "1 credit/5 coins",
+        "incentive: 1@3, 1@5 (2/5)"
+      ],
+      "pricing_chute3": [
+        "same as chute 1",
+        "1 credit/coin",
+        "2 credits/coin",
+        "3 credits/coin",
+        "4 credits/coin",
+        "5 credits/coin",
+        "6 credits/coin",
+        "7 credits/coin",
+        "8 credits/coin",
+        "9 credits/coin",
+        "10 credits/coin",
+        "11 credits/coin",
+        "12 credits/coin",
+        "13 credits/coin",
+        "14 credits/coin",
+        "15 credits/coin"
+      ]
+    }
   },
   "game_state": {
     "_notes": [
@@ -308,6 +370,204 @@
         "max": 3,
         "suffix": " credits"
       }
+    }
+  },
+  "dip_switches": {
+    "1-5": {
+      "_notes": "Full pricing table from the manual; X/2 coins settings pay all credits on the 2nd coin.",
+      "label": "Coin Chute #1 (hinge side) Credits/Coin",
+      "encoding": "dipsw",
+      "offsets": [
+        5,
+        4,
+        3,
+        2,
+        1
+      ],
+      "values": "pricing"
+    },
+    "6": {
+      "label": "Single and Double Lites",
+      "encoding": "dipsw",
+      "offsets": [
+        6
+      ],
+      "values": [
+        "alternate",
+        "always on"
+      ]
+    },
+    "7": {
+      "label": "Flyaway 25K Lite at Start of Game",
+      "encoding": "dipsw",
+      "offsets": [
+        7
+      ],
+      "values": "off_on"
+    },
+    "8": {
+      "label": "Runs to Beat Advances",
+      "encoding": "dipsw",
+      "offsets": [
+        8
+      ],
+      "values": [
+        "stay at set up runs",
+        "step off by 10 after each ten beat (20 after 50)"
+      ]
+    },
+    "9-13": {
+      "_notes": "Full pricing table from the manual; X/2 coins settings pay all credits on the 2nd coin.",
+      "label": "Coin Chute #2 Credits/Coin",
+      "encoding": "dipsw",
+      "offsets": [
+        13,
+        12,
+        11,
+        10,
+        9
+      ],
+      "values": "pricing"
+    },
+    "14": {
+      "label": "Flyaway Special Lite",
+      "encoding": "dipsw",
+      "offsets": [
+        14
+      ],
+      "values": [
+        "special then 50K which stays on",
+        "special and 50K keep alternating"
+      ]
+    },
+    "15": {
+      "label": "Extra Balls per Game",
+      "encoding": "dipsw",
+      "offsets": [
+        15
+      ],
+      "values": [
+        "only 1 extra ball per game",
+        "more than 1 extra ball per game"
+      ]
+    },
+    "16": {
+      "label": "Flyaway Value Lites Recall",
+      "encoding": "dipsw",
+      "offsets": [
+        16
+      ],
+      "values": [
+        "not recalled for next ball",
+        "lit values come on for next ball"
+      ]
+    },
+    "17-20": {
+      "label": "Coin Chute #3 Credits/Coin",
+      "encoding": "dipsw",
+      "offsets": [
+        20,
+        19,
+        18,
+        17
+      ],
+      "values": "pricing_chute3"
+    },
+    "21-23": {
+      "label": "Runs to Beat",
+      "encoding": "dipsw",
+      "offsets": [
+        23,
+        22,
+        21
+      ],
+      "values": [
+        55,
+        50,
+        45,
+        40,
+        35,
+        30,
+        25,
+        20
+      ]
+    },
+    "24": {
+      "label": "S and L Return Lane Lites",
+      "encoding": "dipsw",
+      "offsets": [
+        24
+      ],
+      "values": [
+        "not tied",
+        "tied together"
+      ]
+    },
+    "25-26": {
+      "label": "Maximum Credits",
+      "encoding": "dipsw",
+      "offsets": [
+        26,
+        25
+      ],
+      "values": [
+        10,
+        15,
+        25,
+        40
+      ]
+    },
+    "27": {
+      "label": "Credits Displayed",
+      "encoding": "dipsw",
+      "offsets": [
+        27
+      ],
+      "values": "off_on"
+    },
+    "28": {
+      "label": "Match Feature",
+      "encoding": "dipsw",
+      "offsets": [
+        28
+      ],
+      "values": "off_on"
+    },
+    "29": {
+      "label": "Replays per Game",
+      "encoding": "dipsw",
+      "offsets": [
+        29
+      ],
+      "values": [
+        "only 1 replay per player per game",
+        "all replays earned collected"
+      ]
+    },
+    "30": {
+      "label": "Outhole Bonus Score per Run",
+      "encoding": "dipsw",
+      "offsets": [
+        30
+      ],
+      "values": [
+        "10,000 points",
+        "5,000 points"
+      ]
+    },
+    "31-32": {
+      "label": "Balls per Game",
+      "encoding": "dipsw",
+      "offsets": [
+        31,
+        32
+      ],
+      "values": [
+        3,
+        4,
+        5,
+        2
+      ]
     }
   }
 }

--- a/maps/bally/as-2518-35/system-rom-30.map.json
+++ b/maps/bally/as-2518-35/system-rom-30.map.json
@@ -30,7 +30,70 @@
       "sst",
       "startrek",
       "voltan"
-    ]
+    ],
+    "values": {
+      "_notes": [
+        "DIP switch settings verified against the Bally Kiss (#1152-E), Star Trek (#1148-E) and Paragon manuals.",
+        "Switches 22-24 and 29-31 are game-specific features and are not included here; see the game's manual.",
+        "incentive: X@Y means X credits paid on the Yth coin"
+      ],
+      "off_on": [
+        "off",
+        "on"
+      ],
+      "pricing": [
+        "incentive: 1@1, 2@2 (3/2)",
+        "incentive: 1@1, 2@2 (3/2)",
+        "1 credit/coin",
+        "1 credit/2 coins",
+        "2 credits/coin",
+        "2 credits/2 coins",
+        "3 credits/coin",
+        "3 credits/2 coins",
+        "4 credits/coin",
+        "4 credits/2 coins",
+        "5 credits/coin",
+        "5 credits/2 coins",
+        "6 credits/coin",
+        "6 credits/2 coins",
+        "7 credits/coin",
+        "7 credits/2 coins",
+        "8 credits/coin",
+        "8 credits/2 coins",
+        "9 credits/coin",
+        "9 credits/2 coins",
+        "10 credits/coin",
+        "10 credits/2 coins",
+        "11 credits/coin",
+        "11 credits/2 coins",
+        "12 credits/coin",
+        "12 credits/2 coins",
+        "13 credits/coin",
+        "13 credits/2 coins",
+        "14 credits/coin",
+        "14 credits/2 coins",
+        "15 credits/coin",
+        "15 credits/2 coins"
+      ],
+      "pricing_chute2": [
+        "same as chute 1",
+        "1 credit/coin",
+        "2 credits/coin",
+        "3 credits/coin",
+        "4 credits/coin",
+        "5 credits/coin",
+        "6 credits/coin",
+        "7 credits/coin",
+        "8 credits/coin",
+        "9 credits/coin",
+        "10 credits/coin",
+        "11 credits/coin",
+        "12 credits/coin",
+        "13 credits/coin",
+        "14 credits/coin",
+        "15 credits/coin"
+      ]
+    }
   },
   "game_state": {
     "credits": {
@@ -273,6 +336,134 @@
         "min": 0,
         "max": 999000
       }
+    }
+  },
+  "dip_switches": {
+    "1-5": {
+      "_notes": "Full pricing table from the manuals; X/2 coins settings pay all credits on the 2nd coin. The 3/2 incentive pays 1 credit on the 1st coin and 2 on the 2nd if no scoring occurred in between (1 otherwise).",
+      "label": "Coin Chute #1 (hinge side) Credits/Coin",
+      "encoding": "dipsw",
+      "offsets": [
+        5,
+        4,
+        3,
+        2,
+        1
+      ],
+      "values": "pricing"
+    },
+    "6-7": {
+      "label": "High Score to Date Award",
+      "encoding": "dipsw",
+      "offsets": [
+        7,
+        6
+      ],
+      "values": [
+        "no award",
+        "1 credit",
+        "2 credits",
+        "3 credits"
+      ]
+    },
+    "8,32": {
+      "_notes": "Switches 8 and 32 select one of four melody/noise/chime sets; which sounds map to which setting is game-specific, see the game's manual.",
+      "label": "Sound Option",
+      "encoding": "dipsw",
+      "offsets": [
+        8,
+        32
+      ],
+      "values": [
+        "sound setting 1",
+        "sound setting 2",
+        "sound setting 3",
+        "sound setting 4"
+      ]
+    },
+    "9-13": {
+      "_notes": "Full pricing table from the manuals; X/2 coins settings pay all credits on the 2nd coin. The 3/2 incentive pays 1 credit on the 1st coin and 2 on the 2nd if no scoring occurred in between (1 otherwise).",
+      "label": "Coin Chute #3 Credits/Coin",
+      "encoding": "dipsw",
+      "offsets": [
+        13,
+        12,
+        11,
+        10,
+        9
+      ],
+      "values": "pricing"
+    },
+    "14-15": {
+      "label": "High Score / Special Award Mode",
+      "encoding": "dipsw",
+      "offsets": [
+        15,
+        14
+      ],
+      "values": [
+        "no award",
+        "novelty (points)",
+        "extra ball",
+        "replay"
+      ]
+    },
+    "16": {
+      "label": "Balls per Game",
+      "encoding": "dipsw",
+      "offsets": [
+        16
+      ],
+      "values": [
+        3,
+        5
+      ]
+    },
+    "17-19": {
+      "label": "Maximum Credits",
+      "encoding": "dipsw",
+      "offsets": [
+        19,
+        18,
+        17
+      ],
+      "values": [
+        5,
+        10,
+        15,
+        20,
+        25,
+        30,
+        35,
+        40
+      ]
+    },
+    "20": {
+      "label": "Credits Displayed",
+      "encoding": "dipsw",
+      "offsets": [
+        20
+      ],
+      "values": "off_on"
+    },
+    "21": {
+      "label": "Match Feature",
+      "encoding": "dipsw",
+      "offsets": [
+        21
+      ],
+      "values": "off_on"
+    },
+    "25-28": {
+      "label": "Coin Chute #2 Credits/Coin",
+      "encoding": "dipsw",
+      "offsets": [
+        28,
+        27,
+        26,
+        25
+      ],
+      "values": "pricing_chute2"
     }
   }
 }

--- a/maps/bally/as-2518-35/system-rom-35.map.json
+++ b/maps/bally/as-2518-35/system-rom-35.map.json
@@ -40,7 +40,70 @@
       "slbmanid",
       "spaceinv",
       "viking"
-    ]
+    ],
+    "values": {
+      "_notes": [
+        "DIP switch settings verified against the Bally Viking (#1198), Space Invaders and Harlem Globetrotters On Tour manuals.",
+        "Switches 8, 14-16, 23, 24 and 32 are game-specific features and are not included here; see the game's manual.",
+        "incentive: X@Y means X credits paid on the Yth coin"
+      ],
+      "off_on": [
+        "off",
+        "on"
+      ],
+      "pricing": [
+        "incentive: 1@1, 2@2 (3/2)",
+        "incentive: 1@1, 2@2 (3/2)",
+        "1 credit/coin",
+        "1 credit/2 coins",
+        "2 credits/coin",
+        "2 credits/2 coins",
+        "3 credits/coin",
+        "3 credits/2 coins",
+        "4 credits/coin",
+        "4 credits/2 coins",
+        "5 credits/coin",
+        "5 credits/2 coins",
+        "6 credits/coin",
+        "6 credits/2 coins",
+        "7 credits/coin",
+        "7 credits/2 coins",
+        "8 credits/coin",
+        "8 credits/2 coins",
+        "9 credits/coin",
+        "9 credits/2 coins",
+        "10 credits/coin",
+        "10 credits/2 coins",
+        "11 credits/coin",
+        "11 credits/2 coins",
+        "12 credits/coin",
+        "12 credits/2 coins",
+        "13 credits/coin",
+        "13 credits/2 coins",
+        "14 credits/coin",
+        "14 credits/2 coins",
+        "15 credits/coin",
+        "15 credits/2 coins"
+      ],
+      "pricing_chute2": [
+        "same as chute 1",
+        "1 credit/coin",
+        "2 credits/coin",
+        "3 credits/coin",
+        "4 credits/coin",
+        "5 credits/coin",
+        "6 credits/coin",
+        "7 credits/coin",
+        "8 credits/coin",
+        "9 credits/coin",
+        "10 credits/coin",
+        "11 credits/coin",
+        "12 credits/coin",
+        "13 credits/coin",
+        "14 credits/coin",
+        "15 credits/coin"
+      ]
+    }
   },
   "game_state": {
     "credits": {
@@ -302,6 +365,129 @@
         "min": 0,
         "max": 999000
       }
+    }
+  },
+  "dip_switches": {
+    "1-5": {
+      "_notes": "Full pricing table from the manuals; X/2 coins settings pay all credits on the 2nd coin. The 3/2 incentive pays 1 credit on the 1st coin and 2 on the 2nd if no scoring occurred in between (1 otherwise). Space Invaders' 720-37 U6 ROM ignores switches 1 and 9 (always treated as off) and replaces the two 15 credits settings with a 3/4 coins incentive.",
+      "label": "Coin Chute #1 (hinge side) Credits/Coin",
+      "encoding": "dipsw",
+      "offsets": [
+        5,
+        4,
+        3,
+        2,
+        1
+      ],
+      "values": "pricing"
+    },
+    "6-7": {
+      "_notes": "Both switches off is not documented in the manuals.",
+      "label": "High Score / Special Award Mode",
+      "encoding": "dipsw",
+      "offsets": [
+        7,
+        6
+      ],
+      "values": [
+        "?",
+        "novelty (specials award points, no threshold award)",
+        "extra ball",
+        "replay"
+      ]
+    },
+    "9-13": {
+      "_notes": "Full pricing table from the manuals; X/2 coins settings pay all credits on the 2nd coin. The 3/2 incentive pays 1 credit on the 1st coin and 2 on the 2nd if no scoring occurred in between (1 otherwise). Space Invaders' 720-37 U6 ROM ignores switches 1 and 9 (always treated as off) and replaces the two 15 credits settings with a 3/4 coins incentive.",
+      "label": "Coin Chute #3 Credits/Coin",
+      "encoding": "dipsw",
+      "offsets": [
+        13,
+        12,
+        11,
+        10,
+        9
+      ],
+      "values": "pricing"
+    },
+    "17-20": {
+      "label": "Coin Chute #2 Credits/Coin",
+      "encoding": "dipsw",
+      "offsets": [
+        20,
+        19,
+        18,
+        17
+      ],
+      "values": "pricing_chute2"
+    },
+    "21-22": {
+      "label": "High Score to Date Award",
+      "encoding": "dipsw",
+      "offsets": [
+        22,
+        21
+      ],
+      "values": [
+        "no award",
+        "1 credit",
+        "2 credits",
+        "3 credits"
+      ]
+    },
+    "25-26": {
+      "label": "Maximum Credits",
+      "encoding": "dipsw",
+      "offsets": [
+        26,
+        25
+      ],
+      "values": [
+        10,
+        15,
+        25,
+        40
+      ]
+    },
+    "27": {
+      "label": "Credits Displayed",
+      "encoding": "dipsw",
+      "offsets": [
+        27
+      ],
+      "values": "off_on"
+    },
+    "28": {
+      "label": "Match Feature",
+      "encoding": "dipsw",
+      "offsets": [
+        28
+      ],
+      "values": "off_on"
+    },
+    "29-30": {
+      "label": "Sound Option",
+      "encoding": "dipsw",
+      "offsets": [
+        30,
+        29
+      ],
+      "values": [
+        "chimes on most scoring",
+        "playfield noises without background",
+        "noise effects on most scoring",
+        "playfield noises with background"
+      ]
+    },
+    "31": {
+      "label": "Balls per Game",
+      "encoding": "dipsw",
+      "offsets": [
+        31
+      ],
+      "values": [
+        3,
+        5
+      ]
     }
   }
 }

--- a/maps/bally/as-2518-35/system-rom-53.map.json
+++ b/maps/bally/as-2518-35/system-rom-53.map.json
@@ -41,7 +41,70 @@
       "spyhuntr",
       "vector",
       "xsandos"
-    ]
+    ],
+    "values": {
+      "_notes": [
+        "DIP switch settings verified against the Bally Medusa (#1245) and Fathom manuals (and identical in the Embryon and Grand Slam manuals).",
+        "Switches 6-8, 14-16, 21-24, 29 and 30 are game-specific features and are not included here; see the game's manual.",
+        "incentive: X@Y means X credits paid on the Yth coin"
+      ],
+      "off_on": [
+        "off",
+        "on"
+      ],
+      "pricing": [
+        "1 credit/coin",
+        "2 credits/coin",
+        "3 credits/coin",
+        "4 credits/coin",
+        "5 credits/coin",
+        "6 credits/coin",
+        "7 credits/coin",
+        "8 credits/coin",
+        "9 credits/coin",
+        "12 credits/coin",
+        "14 credits/coin",
+        "1 credit/2 coins",
+        "2 credits/2 coins",
+        "3 credits/2 coins",
+        "4 credits/2 coins",
+        "5 credits/2 coins",
+        "6 credits/2 coins",
+        "7 credits/2 coins",
+        "8 credits/2 coins",
+        "9 credits/2 coins",
+        "12 credits/2 coins",
+        "14 credits/2 coins",
+        "incentive: 1@1, 2@2 (3/2)",
+        "incentive: 1@2, 1@3, 1@4 (3/4)",
+        "incentive: 1@2, 2@4 (3/4)",
+        "incentive: 1@1, 1@2, 1@3, 2@4 (5/4)",
+        "incentive: 1@1, 2@2, 1@3, 3@4 (7/4)",
+        "incentive: 1@1, 2@2, 2@3, 2@4 (7/4)",
+        "1 credit/3 coins",
+        "1 credit/4 coins",
+        "1 credit/5 coins",
+        "incentive: 1@3, 1@5 (2/5)"
+      ],
+      "pricing_chute2": [
+        "same as chute 1",
+        "1 credit/coin",
+        "2 credits/coin",
+        "3 credits/coin",
+        "4 credits/coin",
+        "5 credits/coin",
+        "6 credits/coin",
+        "7 credits/coin",
+        "8 credits/coin",
+        "9 credits/coin",
+        "10 credits/coin",
+        "11 credits/coin",
+        "12 credits/coin",
+        "13 credits/coin",
+        "14 credits/coin",
+        "15 credits/coin"
+      ]
+    }
   },
   "game_state": {
     "_notes": [
@@ -330,6 +393,89 @@
         "max": 3,
         "suffix": " credits"
       }
+    }
+  },
+  "dip_switches": {
+    "1-5": {
+      "_notes": "Full pricing table from the manuals; X/2 coins settings pay all credits on the 2nd coin.",
+      "label": "Coin Chute #1 (hinge side) Credits/Coin",
+      "encoding": "dipsw",
+      "offsets": [
+        5,
+        4,
+        3,
+        2,
+        1
+      ],
+      "values": "pricing"
+    },
+    "9-13": {
+      "_notes": "Full pricing table from the manuals; X/2 coins settings pay all credits on the 2nd coin.",
+      "label": "Coin Chute #3 (right side) Credits/Coin",
+      "encoding": "dipsw",
+      "offsets": [
+        13,
+        12,
+        11,
+        10,
+        9
+      ],
+      "values": "pricing"
+    },
+    "17-20": {
+      "label": "Coin Chute #2 (center) Credits/Coin",
+      "encoding": "dipsw",
+      "offsets": [
+        20,
+        19,
+        18,
+        17
+      ],
+      "values": "pricing_chute2"
+    },
+    "25-26": {
+      "label": "Maximum Credits",
+      "encoding": "dipsw",
+      "offsets": [
+        26,
+        25
+      ],
+      "values": [
+        10,
+        15,
+        25,
+        40
+      ]
+    },
+    "27": {
+      "label": "Credits Displayed",
+      "encoding": "dipsw",
+      "offsets": [
+        27
+      ],
+      "values": "off_on"
+    },
+    "28": {
+      "label": "Match Feature",
+      "encoding": "dipsw",
+      "offsets": [
+        28
+      ],
+      "values": "off_on"
+    },
+    "31-32": {
+      "label": "Balls per Game",
+      "encoding": "dipsw",
+      "offsets": [
+        31,
+        32
+      ],
+      "values": [
+        3,
+        4,
+        5,
+        2
+      ]
     }
   }
 }


### PR DESCRIPTION
Adds `dip_switches` sections for Bally AS-2518-35 games, documented from the original Bally manuals:

- `embryon` and `gransla4`: full per-game documentation, including the complete 31-combination coin chute pricing tables.
- `system-rom-30`, `-35` and `-53`: the system-level switches (coin chutes, max credits, balls, match, credit display, awards, sound), which the manuals confirm are identical across games sharing a U6 ROM - each generation has its own layout. Covers 32 shared-map ROMs. Game-specific feature switches are deliberately omitted and called out in the notes.

Sources: the Kiss, Star Trek, Paragon, Viking, Space Invaders, Harlem Globetrotters, Medusa, Fathom, Embryon and Grand Slam manuals. Verified by decoding real .nv dumps of nine games. Double checked with #99 .