### PR TITLE
whitestar: document and declare the adjustments checksum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -548,6 +548,20 @@ has a checksum that appears in a non-adjacent address.)
 - **checksum16**: An array of memory regions protected by a 16-bit
   checksum.  The last two bytes of the range are the 16-bit result of
   subtracting all prior bytes in the range from `0xFFFF`.
+- **checksum8_sum**: An array of memory regions protected by an 8-bit
+  checksum that stores the sum itself rather than its complement: the
+  checksum byte holds the low byte of the sum of all bytes in the range.
+  Requires the `checksum` field, as the byte lives outside the range it
+  covers.  Repairing such a region additively -- by the delta of the bytes
+  written -- is exact without depending on where the range ends.
+
+(For example, Sega/Stern Whitestar games protect their adjustments block
+this way, with the checksum byte held well past the end of the range.)
+
+This is a separate key rather than a property on `checksum8` so that a reader
+which does not implement it skips the region entirely.  Spelled as a property,
+a reader that ignored the property would still recognise the region and write
+`0xFF - sum` -- a checksum the game rejects.
 
 ### Version History
 #### v0.1
@@ -589,3 +603,5 @@ has a checksum that appears in a non-adjacent address.)
   high scores on first generation Atari).
 - Although not previously mentioned, hex string usage is no longer
   deprecated.  In the majority of cases it's easier to use hex notation.
+- Add `checksum8_sum` for regions whose checksum byte stores the sum itself
+  instead of its complement (needed for Whitestar adjustments).

--- a/maps/sega/whitestar/apollo13.map.json
+++ b/maps/sega/whitestar/apollo13.map.json
@@ -4,7 +4,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 6,
+    "version": 7,
     "copyright": [
       "Copyright (C) 2026 by Tom Collins <tom@scorbit.io>"
     ],
@@ -15,6 +15,14 @@
       "apollo14"
     ]
   },
+  "checksum8_sum": [
+    {
+      "start": "0x1E00",
+      "end": "0x1E7F",
+      "checksum": "0x1FBD",
+      "label": "Adjustments"
+    }
+  ],
   "game_state": {
     "scores": [
       {

--- a/maps/sega/whitestar/startrp.map.json
+++ b/maps/sega/whitestar/startrp.map.json
@@ -4,7 +4,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": [
       "Copyright (C) 2026 by Tom Collins <tom@scorbit.io>"
     ],
@@ -15,6 +15,14 @@
       "startrp2"
     ]
   },
+  "checksum8_sum": [
+    {
+      "start": "0x1E00",
+      "end": "0x1E7F",
+      "checksum": "0x1FBD",
+      "label": "Adjustments"
+    }
+  ],
   "game_state": {
     "scores": [
       {

--- a/maps/sega/whitestar/twst_405.map.json
+++ b/maps/sega/whitestar/twst_405.map.json
@@ -4,7 +4,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 6,
+    "version": 7,
     "copyright": [
       "Copyright (C) 2026 by Tom Collins <tom@scorbit.io>"
     ],
@@ -16,6 +16,14 @@
       "twst_405"
     ]
   },
+  "checksum8_sum": [
+    {
+      "start": "0x1E00",
+      "end": "0x1E7F",
+      "checksum": "0x1FBD",
+      "label": "Adjustments"
+    }
+  ],
   "game_state": {
     "scores": [
       {

--- a/maps/stern/whitestar/lotr.map.json
+++ b/maps/stern/whitestar/lotr.map.json
@@ -4,7 +4,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 2,
+    "version": 3,
     "copyright": [
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
     ],
@@ -29,6 +29,14 @@
       "lotr9"
     ]
   },
+  "checksum8_sum": [
+    {
+      "start": "0x1E00",
+      "end": "0x1E7F",
+      "checksum": "0x1FC1",
+      "label": "Adjustments"
+    }
+  ],
   "game_state": {
     "scores": [
       {

--- a/maps/stern/whitestar/rctycn.map.json
+++ b/maps/stern/whitestar/rctycn.map.json
@@ -4,7 +4,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 6,
+    "version": 7,
     "copyright": [
       "Copyright (C) 2026 by Tom Collins <tom@scorbit.io>"
     ],
@@ -27,6 +27,14 @@
       "rctycnl"
     ]
   },
+  "checksum8_sum": [
+    {
+      "start": "0x1E00",
+      "end": "0x1E7F",
+      "checksum": "0x1FBD",
+      "label": "Adjustments"
+    }
+  ],
   "game_state": {
     "scores": [
       {

--- a/maps/stern/whitestar/shrkysht.map.json
+++ b/maps/stern/whitestar/shrkysht.map.json
@@ -4,7 +4,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": [
       "Copyright (C) 2026 by Tom Collins <tom@scorbit.io>"
     ],
@@ -18,6 +18,14 @@
       "shrkysht"
     ]
   },
+  "checksum8_sum": [
+    {
+      "start": "0x1E00",
+      "end": "0x1E7F",
+      "checksum": "0x1FBD",
+      "label": "Adjustments"
+    }
+  ],
   "game_state": {
     "scores": [
       {

--- a/schema/map.schema.json
+++ b/schema/map.schema.json
@@ -98,6 +98,13 @@
         "$ref": "#/$defs/checksum"
       }
     },
+    "checksum8_sum": {
+      "description": "Regions whose checksum byte stores the low byte of the sum itself rather than its complement.  Requires \"checksum\", as the byte lies outside the range it covers.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/checksum"
+      }
+    },
     "player_state": {
       "description": "Per-player state; structure is still free-form.",
       "type": "object"


### PR DESCRIPTION
Whitestar protects its adjustments block with an 8-bit checksum that stores the sum itself rather than its complement, at a byte outside the range it covers. Nothing in the map set described it, so writing any adjustment in that block leaves the checksum stale and the game discards the change on the next load -- it takes effect for the session, which makes it look like a save failure rather than a validation one.

checksum8 cannot express this: it is defined as complement-to-0xFF. The non-adjacent `checksum` address added in v0.8 covers the other half, so this adds only checksum8_sum, as its own key rather than a property on checksum8 -- a reader that does not implement the key skips the region, where a reader that ignored a property would still recognise the region and write 0xFF - sum.

Region is 0x1E00-0x1E7F on every game examined; only the checksum address varies. Declared on the six games with NVRAM images to support it, three of them confirmed by changing one adjustment through the game's own service menu and capturing a second image:

    startrp2   free play 0x1E04 00->01   0x1FBD 29->2A
    shrkysht   replay %  0x1E01 10->11   0x1FBD 1D->1E
    lotr       replay %  0x1E02 10->11   0x1FC1 0B->0C

apollo13, twst_405 and rctycn are single images: sum(0x1E00..0x1E7F) matches the stored byte, and the match lands on that game's last non-zero adjustment byte, but one image is one equation and that is weaker evidence.

Deliberately not declared on the other 34 whitestar maps. lotr keeps its checksum at 0x1FC1 rather than 0x1FBD, so the address demonstrably varies between titles and cannot be assumed without an image to check against.

The region's end is not tightly bounded. Every image pads 0x1E66-0x1E7F with zeroes, so any end at or past a game's last non-zero adjustment byte fits equally well; 0x1E7F is the widest that holds everywhere, and it matters because 0x1E65 -- the value startrp2 alone suggests -- omits live bytes on shrkysht, which carries adjustments out to 0x1E75. Implementations are best off repairing additively, by the delta of the bytes they wrote, which is exact regardless of where the range truly ends.

The JSON schema added in 0499799 is strict, so schema/map.schema.json gains checksum8_sum alongside checksum8/checksum16; it reuses the existing $defs/checksum, since the entry shape is unchanged. Without that, CI rejects these maps.

Added under v0.8 on the assumption it is still open; happy to move it to v0.9 and bump _fileformat on these maps instead.

I will be checking the rest of Whitestar for completeness. I ran into this while trying to add freeplay directly through nvram editing. Let me know if you want me to do further testing before using any of this.