### PR TITLE
Add new `_metadata.validation` property

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,7 +13,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check for file formatting issues or outdated index.json
         run: |
           shopt -s globstar

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,9 +2,9 @@ name: Validate
 
 on:
   push:
-    branches: [ "master", "main" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master", "main" ]
+    branches: [ "main" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/maps/gottlieb/system80b/victory.map.json
+++ b/maps/gottlieb/system80b/victory.map.json
@@ -8,9 +8,9 @@
     "Note that offsets 248 through 252 are 4-bit checksums of each of the high scores.",
     "Modified version of 80b-8digit-B-12KB.map.json with game-specific DIP switch entries."
   ],
-  "_fileformat": 0.8,
+  "_fileformat": 0.9,
   "_metadata": {
-    "version": 3,
+    "version": 4,
     "copyright": [
       "Copyright (C) 2024 by Tom Collins <tom@tomlogic.com>",
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
@@ -27,6 +27,61 @@
       "victr12",
       "victr13"
     ],
+    "validation": {
+      "checksum": [
+        {
+          "label": "High Score #1",
+          "bits": 4,
+          "start": "0x18B7",
+          "length": 13,
+          "complement": false,
+          "checksum": "0x18F8"
+        },
+        {
+          "label": "High Score #2",
+          "bits": 4,
+          "start": "0x18C4",
+          "length": 13,
+          "complement": false,
+          "checksum": "0x18F9"
+        },
+        {
+          "label": "High Score #3",
+          "bits": 4,
+          "start": "0x18D1",
+          "length": 13,
+          "complement": false,
+          "checksum": "0x18FA"
+        },
+        {
+          "label": "High Score #4",
+          "bits": 4,
+          "start": "0x18DE",
+          "length": 13,
+          "complement": false,
+          "checksum": "0x18FB"
+        },
+        {
+          "label": "High Score #5",
+          "bits": 4,
+          "start": "0x18EB",
+          "length": 13,
+          "complement": false,
+          "checksum": "0x18FC"
+        }
+      ],
+      "mirror": [
+        {
+          "label": "Adjustments",
+          "length": 61,
+          "addresses": [
+            "0x1800",
+            "0x183D",
+            "0x187A"
+          ]
+        }
+      ]
+    },
     "values": {
       "off_on": [
         "off",

--- a/maps/gottlieb/system80b/victory.map.json
+++ b/maps/gottlieb/system80b/victory.map.json
@@ -10,7 +10,7 @@
   ],
   "_fileformat": 0.9,
   "_metadata": {
-    "version": 4,
+    "version": 5,
     "copyright": [
       "Copyright (C) 2024 by Tom Collins <tom@tomlogic.com>",
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
@@ -73,11 +73,12 @@
       "mirror": [
         {
           "label": "Adjustments",
+          "start": "0x1800",
           "length": 61,
-          "addresses": [
-            "0x1800",
-            "0x183D",
-            "0x187A"
+          "offsets": [
+            0,
+            61,
+            122
           ]
         }
       ]

--- a/maps/stern/sam/st_162h.map.json
+++ b/maps/stern/sam/st_162h.map.json
@@ -20,7 +20,7 @@
   ],
   "_fileformat": 0.7,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": [
       "Copyright (C)2024 by Tom Collins <tom@tomlogic.com>",
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
@@ -30,7 +30,61 @@
     "roms": [
       "st_162h",
       "st_162hc"
-    ]
+    ],
+    "validation": {
+      "checksum": [
+        {
+          "_notes": "119 adjustments: 4-byte LE value, 1-byte checksum, 3 bytes 0xFF padding",
+          "repeat": {
+            "count": 119,
+            "step": 8
+          },
+          "label": "Adjustment {#} (checksum)",
+          "start": "0x02102008",
+          "length": 5,
+          "complement": true
+        },
+        {
+          "_notes": "65 audits: 4-byte LE value, 4 bytes observed always zero, 4-byte copy of the value, 1-byte checksum over those 12, 3 bytes 0xFF padding. The copy is written in the same instant as the value; a writer must update both and the checksum.",
+          "repeat": {
+            "count": 65,
+            "step": 16
+          },
+          "label": "Audit {#} (checksum)",
+          "start": "0x021023D0",
+          "length": 13,
+          "complement": true
+        },
+        {
+          "_notes": "8 champion records: 28 bytes of initials and score, 2-byte LE checksum, 2 slack bytes",
+          "label": "Champion record {#} (checksum)",
+          "start": "0x02102ED0",
+          "repeat": {
+            "count": 8,
+            "step": 32
+          },
+          "length": 30,
+          "bits": 16,
+          "complement": true
+        }
+      ],
+      "mirror": [
+        {
+          "_notes": "65 audits: 4-byte LE value, 4 bytes observed always zero, 4-byte copy of the value, 1-byte checksum over those 12, 3 bytes 0xFF padding. The copy is written in the same instant as the value; a writer must update both and the checksum.",
+          "repeat": {
+            "count": 65,
+            "step": 16
+          },
+          "start": "0x021023D0",
+          "label": "Audit {#} (mirror)",
+          "length": 4,
+          "offsets": [
+            0,
+            8
+          ]
+        }
+      ]
+    }
   },
   "game_state": {
     "player_count": {

--- a/maps/stern/whitestar/lotr.map.json
+++ b/maps/stern/whitestar/lotr.map.json
@@ -2,9 +2,9 @@
   "_notes": [
     "Compiled by Tom Collins, based on simpprty."
   ],
-  "_fileformat": 0.8,
+  "_fileformat": 0.9,
   "_metadata": {
-    "version": 2,
+    "version": 3,
     "copyright": [
       "Copyright (C) 2025 by Tom Collins <tom@scorbit.io>"
     ],
@@ -27,7 +27,18 @@
       "lotr",
       "lotr8",
       "lotr9"
-    ]
+    ],
+    "validation": {
+      "checksum": [
+        {
+          "label": "Adjustments",
+          "start": "0x1E00",
+          "length": "0x63",
+          "complement": false,
+          "checksum": "0x1FC1"
+        }
+      ]
+    }
   },
   "game_state": {
     "scores": [

--- a/schema/map.schema.json
+++ b/schema/map.schema.json
@@ -87,15 +87,19 @@
       }
     },
     "checksum8": {
+      "description": "deprecated by _metadata.validation.checksum",
+      "deprecated": true,
       "type": "array",
       "items": {
-        "$ref": "#/$defs/checksum"
+        "$ref": "#/$defs/old_checksum"
       }
     },
     "checksum16": {
+      "description": "deprecated by _metadata.validation.checksum",
+      "deprecated": true,
       "type": "array",
       "items": {
-        "$ref": "#/$defs/checksum"
+        "$ref": "#/$defs/old_checksum"
       }
     },
     "player_state": {
@@ -188,6 +192,24 @@
           "description": "Characters to use for the ch encoding instead of a straight ASCII table.",
           "type": "string"
         },
+        "validation": {
+          "description": "Lists of memory regions validated in some way (checksum or mirroring) by the ROM.",
+          "type": "object",
+          "properties": {
+            "checksum": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/new_checksum"
+              }
+            },
+            "mirror": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/mirror"
+              }
+            }
+          }
+        },
         "values": {
           "description": "Value lists that descriptors can reference by key instead of repeating the full list.",
           "type": "object",
@@ -199,6 +221,7 @@
       "required": [
         "version",
         "roms",
+        "license",
         "platform"
       ],
       "additionalProperties": false
@@ -212,6 +235,12 @@
           "boolean"
         ]
       }
+    },
+    "length": {
+      "description": "field used in descriptors and elsewhere",
+      "$ref": "#/$defs/intOrHex",
+      "minimum": 1,
+      "default": 1
     },
     "descriptor": {
       "description": "A region of memory and how to interpret it. See Descriptors in README.md.",
@@ -233,8 +262,7 @@
           "$ref": "#/$defs/intOrHex"
         },
         "length": {
-          "type": "integer",
-          "minimum": 1
+          "$ref": "#/$defs/length"
         },
         "offsets": {
           "type": "array",
@@ -296,15 +324,18 @@
           "type": "integer"
         },
         "scale": {
-          "type": "number"
+          "type": "number",
+          "default": 1
         },
         "offset": {
-          "type": "integer"
+          "type": "integer",
+          "default": 0
         },
         "mask": {
           "$ref": "#/$defs/intOrHex"
         },
         "nibble": {
+          "description": "portion of each byte to use (low/high/both 4-bit halves); defaults to value from platform file",
           "enum": [
             "low",
             "high",
@@ -312,6 +343,7 @@
           ]
         },
         "endian": {
+          "description": "big or little-endian byte ordering; defaults to value from platform file",
           "enum": [
             "big",
             "little"
@@ -319,9 +351,11 @@
         },
         "null": {
           "enum": [
+            "ignore",
             "truncate",
             "terminate"
-          ]
+          ],
+          "default": "ignore"
         },
         "units": {
           "enum": [
@@ -333,7 +367,8 @@
           "type": "string"
         },
         "invert": {
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         }
       },
       "required": [
@@ -413,7 +448,8 @@
         }
       }
     },
-    "checksum": {
+    "old_checksum": {
+      "description": "Used for top-level, deprecated checksum8 and checksum16",
       "type": "object",
       "properties": {
         "_notes": {
@@ -429,8 +465,7 @@
           "$ref": "#/$defs/intOrHex"
         },
         "length": {
-          "type": "integer",
-          "minimum": 1
+          "$ref": "#/$defs/length"
         },
         "groupings": {
           "type": "integer",
@@ -443,6 +478,81 @@
       },
       "required": [
         "start"
+      ],
+      "additionalProperties": false
+    },
+    "new_checksum": {
+      "description": "from _metadata.validation.checksum[]",
+      "type": "object",
+      "properties": {
+        "_notes": {
+          "$ref": "#/$defs/notes"
+        },
+        "label": {
+          "type": "string"
+        },
+        "start": {
+          "$ref": "#/$defs/intOrHex"
+        },
+        "end": {
+          "$ref": "#/$defs/intOrHex"
+        },
+        "length": {
+          "$ref": "#/$defs/length"
+        },
+        "bits": {
+          "description": "Size of final checksum in bits.",
+          "enum": [
+            4,
+            8,
+            16
+          ],
+          "default": 8
+        },
+        "groupings": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "checksum": {
+          "description": "Location of the checksum when it is not adjacent to the checksummed range.",
+          "$ref": "#/$defs/intOrHex"
+        },
+        "complement": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "start",
+        "complement"
+      ],
+      "additionalProperties": false
+    },
+    "mirror": {
+      "description": "from _metadata.validation.mirror[]",
+      "type": "object",
+      "properties": {
+        "_notes": {
+          "$ref": "#/$defs/notes"
+        },
+        "label": {
+          "type": "string"
+        },
+        "length": {
+          "description": "Length (in addresses) of mirrored memory region.",
+          "$ref": "#/$defs/length"
+        },
+        "addresses": {
+          "description": "Starting address for each memory region mirrored.",
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "$ref": "#/$defs/intOrHex"
+          }
+        }
+      },
+      "required": [
+        "length",
+        "addresses"
       ],
       "additionalProperties": false
     }

--- a/schema/map.schema.json
+++ b/schema/map.schema.json
@@ -12,7 +12,8 @@
       "description": "The file's format version. See Version History in README.md.",
       "enum": [
         0.7,
-        0.8
+        0.8,
+        0.9
       ]
     },
     "_metadata": {
@@ -182,7 +183,9 @@
           ]
         },
         "license": {
-          "type": "string"
+          "enum": [
+            "Open Data Commons Open Database License (ODbL) v1.0"
+          ]
         },
         "platform": {
           "description": "Name of a JSON file in the top-level platforms/ directory, without the .json extension.",

--- a/schema/map.schema.json
+++ b/schema/map.schema.json
@@ -512,9 +512,8 @@
           ],
           "default": 8
         },
-        "groupings": {
-          "type": "integer",
-          "minimum": 1
+        "repeat": {
+          "$ref": "#/$defs/repeat"
         },
         "checksum": {
           "description": "Location of the checksum when it is not adjacent to the checksummed range.",
@@ -537,15 +536,23 @@
         "_notes": {
           "$ref": "#/$defs/notes"
         },
+        "repeat": {
+          "$ref": "#/$defs/repeat"
+        },
         "label": {
           "type": "string"
+        },
+        "start": {
+          "description": "Starting address for first mirrored area (default=0x0000).",
+          "$ref": "#/$defs/intOrHex",
+          "default": 0
         },
         "length": {
           "description": "Length (in addresses) of mirrored memory region.",
           "$ref": "#/$defs/length"
         },
-        "addresses": {
-          "description": "Starting address for each memory region mirrored.",
+        "offsets": {
+          "description": "Offsets from `start` for each memory region mirrored.",
           "type": "array",
           "minItems": 2,
           "items": {
@@ -555,7 +562,25 @@
       },
       "required": [
         "length",
-        "addresses"
+        "offsets"
+      ],
+      "additionalProperties": false
+    },
+    "repeat": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "description": "number of times to repeat this entry",
+          "$ref": "#/$defs/intOrHex"
+        },
+        "step": {
+          "description": "amount added to `start` on each repetition",
+          "$ref": "#/$defs/intOrHex"
+        }
+      },
+      "required": [
+        "count",
+        "step"
       ],
       "additionalProperties": false
     }

--- a/schema/platform.schema.json
+++ b/schema/platform.schema.json
@@ -15,7 +15,8 @@
       "enum": [
         "big",
         "little"
-      ]
+      ],
+      "default": "big"
     },
     "memory_layout": {
       "type": "array",
@@ -83,7 +84,8 @@
             "low",
             "high",
             "both"
-          ]
+          ],
+          "default": "both"
         }
       },
       "required": [

--- a/tools/normalize-map.py
+++ b/tools/normalize-map.py
@@ -12,6 +12,9 @@ Usage:
 
 File format updates
 -------------------
+* v0.9:
+    - new _metadata.validation
+
 * v0.8:
     - checksum8/checksum16 objects can have a checksum property
     - new 'bool' encoding
@@ -63,6 +66,9 @@ def map_convert(pairs):
         # set minimum file format based on appearance of certain keys
         if k == '_fileformat':
             minimum_file_format(v)
+        elif k == 'validation':
+            # _metadata.validation added in v0.9
+            minimum_file_format(0.9)
         elif k == 'checksum':
             # checksum attribute for checksum8/checksum16 objects added in v0.8
             minimum_file_format(0.8)


### PR DESCRIPTION
This is a work in progress for review from others (@evilwraith, @francisdb).

- updated schemas to accept new map format
- example of validation.checksum with "complement: false"
- example of validation.mirror
- example of validation.checksum with "bits: 4"

Future:
- documentation
- conversion of checksum8/checksum16 records by normalize-map.py

See GitHub issue #179.