### PR TITLE
Williams System 6: fix `game_over` issue and add method to identify HSTD on displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,12 @@ The following should use an encoding of `bool`:
 - **free_play**: Whether the game is configured for Free Play.
 - **game_over**: Whether the game is in progress (false) or over (true).
 - **tilted**: Current player has tilted their ball.
+- **ignore_scores**: Indicates that values decoded from `game_state.scores`
+    are not considered valid at this time.  For example, some early solid
+    state machines store scores in memory mapped to the displays and will
+    overwrite a score in order to display the high score to date (HSTD).
+    Maps like Williams System 6 signal an "ignore scores" state by using
+    memory mapped to the lamp matrix to identify the HSTD lamp.
 
 ### DIP Switches
 

--- a/maps/williams/system6/README.md
+++ b/maps/williams/system6/README.md
@@ -21,3 +21,17 @@ makes it easier to detect.
 Note: Firepower (and possibly other games) doesn't back up the tens
 digit to 0x72, so the game always shows 00 for that player's score
 during attract mode.
+
+## Game Status
+
+Games set bits of the byte at 0x78 to indicate things like game over, tilt,
+extra ball, and playfield qualified.  We originally used bit 0 to identify
+a "game over" state, but Wes Smith reported (see GitHub issue #171) that
+the game writes 0xFF to 0x78 between balls which will trigger an early
+game over.
+
+One possible solution is to look at the bottom two bits (bit 1 is tilt)
+and only accept a true "game over" when they's set to `01`.  Another
+solution is to compare `current_ball` to 0 since we're reading display
+memory, and it's set to zero from the match sequence.  But that display
+remains set to ` 3` when match is disabled.

--- a/maps/williams/system6/algar.map.json
+++ b/maps/williams/system6/algar.map.json
@@ -7,7 +7,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "Open Data Commons Open Database License (ODbL) v1.0",
     "platform": "williams-system6-6K",
@@ -24,6 +24,7 @@
       "encoding": "bcd"
     },
     "status": {
+      "_notes": "game sets this byte to 0xFF between balls during bonus count",
       "label": "Game Status",
       "start": "0x78",
       "encoding": "bits",
@@ -45,10 +46,17 @@
       "encoding": "bool"
     },
     "game_over": {
+      "_notes": "see `status` note; truly over when tilt=0 and game over=1",
       "label": "Game Over",
       "start": "0x78",
-      "mask": "0x01",
-      "encoding": "bool"
+      "mask": "0x03",
+      "encoding": "enum",
+      "values": [
+        false,
+        true,
+        false,
+        false
+      ]
     },
     "scores": [
       {

--- a/maps/williams/system6/algar.map.json
+++ b/maps/williams/system6/algar.map.json
@@ -7,7 +7,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 6,
+    "version": 7,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "Open Data Commons Open Database License (ODbL) v1.0",
     "platform": "williams-system6-6K",
@@ -57,6 +57,13 @@
         false,
         false
       ]
+    },
+    "ignore_scores": {
+      "_notes": "Score memory might be high score if HSTD lamp is lit.",
+      "label": "Ignore Scores",
+      "start": "0x17",
+      "mask": "0x80",
+      "encoding": "bool"
     },
     "scores": [
       {

--- a/maps/williams/system6/alien_poker.map.json
+++ b/maps/williams/system6/alien_poker.map.json
@@ -7,7 +7,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 6,
+    "version": 7,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "Open Data Commons Open Database License (ODbL) v1.0",
     "platform": "williams-system6-6K",
@@ -61,6 +61,13 @@
         false,
         false
       ]
+    },
+    "ignore_scores": {
+      "_notes": "Score memory might be high score if HSTD lamp is lit.",
+      "label": "Ignore Scores",
+      "start": "0x17",
+      "mask": "0x80",
+      "encoding": "bool"
     },
     "scores": [
       {

--- a/maps/williams/system6/alien_poker.map.json
+++ b/maps/williams/system6/alien_poker.map.json
@@ -7,7 +7,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "Open Data Commons Open Database License (ODbL) v1.0",
     "platform": "williams-system6-6K",
@@ -28,6 +28,7 @@
       "encoding": "bcd"
     },
     "status": {
+      "_notes": "game sets this byte to 0xFF between balls during bonus count",
       "label": "Game Status",
       "start": "0x78",
       "encoding": "bits",
@@ -49,10 +50,17 @@
       "encoding": "bool"
     },
     "game_over": {
+      "_notes": "see `status` note; truly over when tilt=0 and game over=1",
       "label": "Game Over",
       "start": "0x78",
-      "mask": "0x01",
-      "encoding": "bool"
+      "mask": "0x03",
+      "encoding": "enum",
+      "values": [
+        false,
+        true,
+        false,
+        false
+      ]
     },
     "scores": [
       {

--- a/maps/williams/system6/flash_l1.map.json
+++ b/maps/williams/system6/flash_l1.map.json
@@ -8,7 +8,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 6,
+    "version": 7,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "Open Data Commons Open Database License (ODbL) v1.0",
     "platform": "williams-system6-6K",
@@ -60,6 +60,13 @@
         false,
         false
       ]
+    },
+    "ignore_scores": {
+      "_notes": "Score memory might be high score if HSTD lamp is lit.",
+      "label": "Ignore Scores",
+      "start": "0x17",
+      "mask": "0x80",
+      "encoding": "bool"
     },
     "scores": [
       {

--- a/maps/williams/system6/flash_l1.map.json
+++ b/maps/williams/system6/flash_l1.map.json
@@ -8,7 +8,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "Open Data Commons Open Database License (ODbL) v1.0",
     "platform": "williams-system6-6K",
@@ -27,6 +27,7 @@
       "encoding": "bcd"
     },
     "status": {
+      "_notes": "game sets this byte to 0xFF between balls during bonus count",
       "label": "Game Status",
       "start": "0x78",
       "encoding": "bits",
@@ -48,10 +49,17 @@
       "encoding": "bool"
     },
     "game_over": {
+      "_notes": "see `status` note; truly over when tilt=0 and game over=1",
       "label": "Game Over",
       "start": "0x78",
-      "mask": "0x01",
-      "encoding": "bool"
+      "mask": "0x03",
+      "encoding": "enum",
+      "values": [
+        false,
+        true,
+        false,
+        false
+      ]
     },
     "scores": [
       {

--- a/maps/williams/system6/frpwr_l6.map.json
+++ b/maps/williams/system6/frpwr_l6.map.json
@@ -8,7 +8,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 6,
+    "version": 7,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "Open Data Commons Open Database License (ODbL) v1.0",
     "platform": "williams-system6-7.5K",
@@ -62,6 +62,13 @@
         false,
         false
       ]
+    },
+    "ignore_scores": {
+      "_notes": "Score memory might be high score if HSTD lamp is lit.",
+      "label": "Ignore Scores",
+      "start": "0x17",
+      "mask": "0x80",
+      "encoding": "bool"
     },
     "scores": [
       {

--- a/maps/williams/system6/frpwr_l6.map.json
+++ b/maps/williams/system6/frpwr_l6.map.json
@@ -8,7 +8,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "Open Data Commons Open Database License (ODbL) v1.0",
     "platform": "williams-system6-7.5K",
@@ -29,6 +29,7 @@
       "encoding": "bcd"
     },
     "status": {
+      "_notes": "game sets this byte to 0xFF between balls during bonus count",
       "label": "Game Status",
       "start": "0x78",
       "encoding": "bits",
@@ -50,10 +51,17 @@
       "encoding": "bool"
     },
     "game_over": {
+      "_notes": "see `status` note; truly over when tilt=0 and game over=1",
       "label": "Game Over",
       "start": "0x78",
-      "mask": "0x01",
-      "encoding": "bool"
+      "mask": "0x03",
+      "encoding": "enum",
+      "values": [
+        false,
+        true,
+        false,
+        false
+      ]
     },
     "scores": [
       {

--- a/maps/williams/system6/generic.map.json
+++ b/maps/williams/system6/generic.map.json
@@ -8,7 +8,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 6,
+    "version": 7,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "Open Data Commons Open Database License (ODbL) v1.0",
     "platform": "williams-system6-6K",
@@ -87,6 +87,13 @@
         false,
         false
       ]
+    },
+    "ignore_scores": {
+      "_notes": "Score memory might be high score if HSTD lamp is lit.",
+      "label": "Ignore Scores",
+      "start": "0x17",
+      "mask": "0x80",
+      "encoding": "bool"
     },
     "scores": [
       {

--- a/maps/williams/system6/generic.map.json
+++ b/maps/williams/system6/generic.map.json
@@ -8,7 +8,7 @@
   ],
   "_fileformat": 0.8,
   "_metadata": {
-    "version": 5,
+    "version": 6,
     "copyright": "Copyright (C) 2025 by Tom Collins <tom@tomlogic.com>",
     "license": "Open Data Commons Open Database License (ODbL) v1.0",
     "platform": "williams-system6-6K",
@@ -54,6 +54,7 @@
       "encoding": "bcd"
     },
     "status": {
+      "_notes": "game sets this byte to 0xFF between balls during bonus count",
       "label": "Game Status",
       "start": "0x78",
       "encoding": "bits",
@@ -75,10 +76,17 @@
       "encoding": "bool"
     },
     "game_over": {
+      "_notes": "see `status` note; truly over when tilt=0 and game over=1",
       "label": "Game Over",
       "start": "0x78",
-      "mask": "0x01",
-      "encoding": "bool"
+      "mask": "0x03",
+      "encoding": "enum",
+      "values": [
+        false,
+        true,
+        false,
+        false
+      ]
     },
     "scores": [
       {


### PR DESCRIPTION
These changes fix a problem with false `game_over` triggering, and provides a new key (`game_state.ignore_scores`) that map consumers can use to identify when the game is showing HSTD on one of the player score displays.

Resolves #171 and #172.